### PR TITLE
fix(utilities): dom ready state helper

### DIFF
--- a/src/plugins/initial-tags.js
+++ b/src/plugins/initial-tags.js
@@ -1,5 +1,5 @@
 import logger from '../utils/logger';
-import {defaults} from '../utils/utilities';
+import {defaults, waitForDomToBeReady} from '../utils/utilities';
 
 export const DEFAULT_EVENT = 'click';
 
@@ -19,8 +19,8 @@ function InitialTags(tracker, opts) {
   this.tracker = tracker;
   this.tagSelector = `[${this.opts.attributePrefix}initial-tags]`;
 
-  // Wait for DOM to be ready before calling it
-  document.addEventListener('DOMContentLoaded', () => {
+  // Wait for DOM to be ready before parsing initial tags
+  waitForDomToBeReady(() => {
     setTimeout(this.parseInitialTags.bind(this), this.opts.initialTagsDelay);
   });
 }

--- a/src/plugins/pageview-tracker.js
+++ b/src/plugins/pageview-tracker.js
@@ -1,4 +1,6 @@
-import {defaults, getBrowserPageview, isObject, areDifferent, camelize} from '../utils/utilities';
+import {
+  defaults, getBrowserPageview, isObject, areDifferent, camelize, waitForDomToBeReady,
+} from '../utils/utilities';
 import logger from '../utils/logger';
 
 /**
@@ -27,11 +29,8 @@ export default class InitialPageview {
       this.startHotReload();
     }
 
-    // Wait for DOM to be ready before calling it
-    document.addEventListener('DOMContentLoaded', () => {
-      // Initial pageview send
-      this.send();
-    });
+    // Wait for DOM to be ready before sending the first pageview
+    waitForDomToBeReady(() => this.send());
   }
 
   /**

--- a/src/utils/utilities.js
+++ b/src/utils/utilities.js
@@ -167,3 +167,19 @@ export const getOptionalConfig = (configs) => {
 
   return {};
 };
+
+/**
+ * As the library can be loaded async we need this helper to condition some logic
+ * only if the DOM is ready.
+ * But if it is loaded synchronously the callback will be triggered immediately
+ * @param {function} callback - callback
+ */
+export const waitForDomToBeReady = (callback) => {
+  if (document.readyState === 'complete') {
+    callback();
+  } else {
+    document.addEventListener('DOMContentLoaded', () => {
+      callback();
+    });
+  }
+};


### PR DESCRIPTION
As the library can be loaded async we need this helper to condition some logic
only if the DOM is ready.
But if it is loaded synchronously the callback will be triggered immediately