### PR TITLE
fix(jwlpayer): restrain events scope

### DIFF
--- a/src/plugins/__test__/jwplayer-tracker.spec.js
+++ b/src/plugins/__test__/jwplayer-tracker.spec.js
@@ -43,14 +43,14 @@ describe('(Plugin) jwplayer tracker', () => {
       instance = getInstance({jwplayer});
     });
 
-    it('should track "all" event case', () => {
-      instance.onEvent('all', 'foo', {bar: 'baz'});
-      expect(tracker.send.calledWith('jwplayer', {obj: 'foo', bar: 'baz'}));
+    it('should not track "all" event case', () => {
+      instance.onEvent(instance, 'all', {bar: 'baz'});
+      expect(tracker.send.called).equals(false);
     });
 
-    it('should track "default" event case', () => {
-      instance.onEvent('foo', {bar: 'baz'});
-      expect(tracker.send.calledWith('jwplayer', {obj: 'foo', bar: 'baz'}));
+    it('should track "play" event case', () => {
+      instance.onEvent(instance, 'play', {oldstate: 'foo'});
+      expect(tracker.send.calledWith('jwplayer', {act: 'play', desc: 'foo'})).equals(true);
     });
   });
 
@@ -110,7 +110,7 @@ describe('(Plugin) jwplayer tracker', () => {
     });
 
     it('should track the removed instance', () => {
-      expect(tracker.send.calledWith('jwplayer', {obj: 'remove', val: 'foo'}));
+      expect(tracker.send.calledWith('jwplayer', {obj: 'remove', val: 'foo'})).equals(true);
     });
   });
 });

--- a/src/plugins/jwplayer-tracker.js
+++ b/src/plugins/jwplayer-tracker.js
@@ -82,7 +82,7 @@ export default class {
    * @param {object} data* - optional data for 'all' event case
    */
   onEvent(instance, eventName, data = {}) {
-    let tag = {};
+    let tag = null;
 
     switch (eventName) {
       case 'playlistItem':
@@ -128,7 +128,9 @@ export default class {
         break;
     }
 
-    this.tracker.send('jwplayer', tag);
+    if (tag) {
+      this.tracker.send('jwplayer', tag);
+    }
   }
 
   /**


### PR DESCRIPTION
only autoData scoped events are allowed for jwplayer tracking