### PR TITLE
refactor(libs): remove lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
   },
   "dependencies": {
     "debounce": "^1.0.2",
+    "deepmerge": "^2.0.1",
     "delegate": "^3.1.3",
-    "lodash": "^4.17.4",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "webpack-bundle-analyzer": "^2.9.0"

--- a/src/autodata.js
+++ b/src/autodata.js
@@ -1,4 +1,4 @@
-import defaultsDeep from 'lodash/defaultsDeep';
+import deepMerge from 'deepmerge';
 import * as plugins from './plugins';
 import * as tagTypes from './constants/tagTypes';
 import * as errors from './constants/errors';
@@ -14,8 +14,8 @@ const futureInit = ({common, ...rest}) => {
     throw new Error(errors.NO_MULTIPLE_INIT);
   }
 
-  // Merge optional config with common
-  const config = defaultsDeep(getOptionalConfig(rest), common);
+  // Merge deeply optional config with common
+  const config = deepMerge(getOptionalConfig(rest), common);
 
   driver = getInstance(config);
 

--- a/src/demo/demo.jsx
+++ b/src/demo/demo.jsx
@@ -26,7 +26,6 @@ const htmlLogger = (tag) => {
 
 autoData.init({
   common: {
-    debug: 'debug',
     tms: {
       name: 'gtm',
     },
@@ -100,6 +99,7 @@ autoData.init({
     },
   },
   demo: {
+    debug: 'debug',
     tms: {
       sender: htmlLogger,
     },

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,6 +1,4 @@
 /* eslint-disable no-confusing-arrow */
-import findIndex from 'lodash/findIndex';
-
 const log = {};
 const noop = () => {};
 
@@ -31,7 +29,12 @@ const bindLevels = (target, enabled = true) => {
 };
 
 export const setLevel = (levelName) => {
-  const levelIndex = findIndex(levels, ({level}) => level === levelName);
+  let levelIndex = -1;
+  levels.forEach(({level}, idx) => {
+    if (level === levelName) {
+      levelIndex = idx;
+    }
+  });
 
   if (levelIndex !== -1) {
     bindLevels(levels.slice(0, levelIndex), false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2078,6 +2078,10 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+deepmerge@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.0.1.tgz#25c1c24f110fb914f80001b925264dd77f3f4312"
+
 defaults@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"


### PR DESCRIPTION
- lodash was used only for deep merge, using a tiny library instead to free space on final bundle