### PR TITLE
feat(jwplayer): plugin revision

### DIFF
--- a/docs/plugins/JWPLAYER-TRACKER.md
+++ b/docs/plugins/JWPLAYER-TRACKER.md
@@ -64,3 +64,18 @@ jwplayer('myDiv').setup({
 });
 }
 ```
+
+### cuepoints (optional)
+
+Launch an event when threshold or percent of video is reached.
+
+```
+{
+  cuepoints: {
+    thresholds: [10, 30, 60, 120],
+    percentages: [25, 50, 75],
+  }
+}
+```
+
+In the example above, an event is sent at each percent set in `percentages` and at each second set in `thresholds`.

--- a/src/plugins/__test__/jwplayer-tracker.spec.js
+++ b/src/plugins/__test__/jwplayer-tracker.spec.js
@@ -38,9 +38,11 @@ describe('(Plugin) jwplayer tracker', () => {
 
   context('onEvent', () => {
     let instance;
+    const itemInfos = {title: '', file: '', id: ''};
 
     beforeEach(() => {
       instance = getInstance({jwplayer});
+      instance.getPlaylistItem = () => itemInfos;
     });
 
     it('should not track "all" event case', () => {
@@ -50,9 +52,90 @@ describe('(Plugin) jwplayer tracker', () => {
 
     it('should track "play" event case', () => {
       instance.onEvent(instance, 'play', {oldstate: 'foo'});
-      expect(tracker.send.calledWith('jwplayer', {act: 'play', desc: 'foo'})).equals(true);
+      expect(tracker.send.calledWith('jwplayer', {act: 'play', ...itemInfos, desc: 'foo'}))
+        .equals(true);
     });
   });
+
+  context('onTimeEvent', () => {
+    let instance;
+
+    beforeEach(() => {
+      instance = getInstance({jwplayer});
+      instance.opts = {
+        cuepoints: {
+          percentages: [5, 50, 75],
+          thresholds: [20, 30, 60, 120],
+        },
+      };
+      instance.uc = {
+        percentages: [5, 50, 75],
+        thresholds: [20, 30, 60, 120],
+      };
+    });
+
+    it('should return null when no value is reached', () => {
+      const data = {position: 4, duration: 120};
+      expect(instance.onTimeEvent(data)).equals(null);
+    });
+
+    it('should return an object with correct cuepoint type (threshold)', () => {
+      const data = {position: 30, duration: 120};
+      expect(instance.onTimeEvent(data)).deep.equals({
+        act: 'cuepoint',
+        cuepointType: 'threshold',
+        cuepointValue: 30,
+      });
+    });
+
+    it('should return an object with correct cuepoint type (percentage)', () => {
+      const data = {position: 5, duration: 100};
+      expect(instance.onTimeEvent(data)).deep.equals({
+        act: 'cuepoint',
+        cuepointType: 'percentage',
+        cuepointValue: 5,
+      });
+    });
+  });
+
+  context('calculateUnreachedCuepoints', () => {
+    let instance;
+
+    beforeEach(() => {
+      instance = getInstance({jwplayer});
+      instance.opts = {
+        cuepoints: {
+          percentages: [25, 50, 75],
+          thresholds: [20, 30, 60, 120],
+        },
+      };
+      instance.uc = {
+        percentages: [25, 50, 75],
+        thresholds: [20, 30, 60, 120],
+      };
+    });
+
+    it('should return all cue points not reached', () => {
+      instance.calculateUnreachedCuepoints(0, 120);
+      expect(instance.uc).deep.equals({
+        percentages: [25, 50, 75],
+        thresholds: [20, 30, 60, 120],
+      });
+
+      instance.calculateUnreachedCuepoints(35, 100);
+      expect(instance.uc).deep.equals({
+        percentages: [50, 75],
+        thresholds: [60, 120],
+      });
+
+      instance.calculateUnreachedCuepoints(99, 100);
+      expect(instance.uc).deep.equals({
+        percentages: [],
+        thresholds: [120],
+      });
+    });
+  });
+
 
   context('setInstance', () => {
     let instance;
@@ -74,12 +157,14 @@ describe('(Plugin) jwplayer tracker', () => {
     });
 
     [
+      'firstFrame',
       'playlistItem',
       'play',
       'pause',
       'complete',
       'error',
       'seek',
+      'time',
       'mute',
       'volume',
       'fullscreen',

--- a/src/utils/utilities.js
+++ b/src/utils/utilities.js
@@ -183,3 +183,12 @@ export const waitForDomToBeReady = (callback) => {
     });
   }
 };
+
+/**
+ * Get playback percentage of the playlist item
+ * @param {number} cuepointValue - value of the cuepoint in seconds
+ * @param {number} duration - duration of the current playlist item in seconds.
+ * @returns {number} percentage in absolute
+ */
+export const getPlaybackPercentage = (cuepointValue, duration) =>
+  Math.trunc((cuepointValue / duration) * 100);

--- a/src/utils/utilities.spec.js
+++ b/src/utils/utilities.spec.js
@@ -4,6 +4,7 @@ import {
   getBrowserPageview,
   areDifferent,
   camelize,
+  getPlaybackPercentage,
 } from './utilities';
 
 describe('(Utils) utilities', () => {
@@ -51,6 +52,14 @@ describe('(Utils) utilities', () => {
 
     it('should return the original value without trying to camelize it', () => {
       expect(camelize(123)).equals(123);
+    });
+  });
+
+  context('getPlaybackPercentage', () => {
+    it('should return a correct percentage', () => {
+      expect(getPlaybackPercentage(30, 100)).equals(30);
+      expect(getPlaybackPercentage(30, 200)).equals(15);
+      expect(getPlaybackPercentage(87, 162)).equals(53);
     });
   });
 });


### PR DESCRIPTION
Pull request contains:
- Add video started (i.e. loaded) and video ended in event list
- Update existing tags which don't have enough datas
- Launch an event when a cue point or percent of video is reached, and allow developer to configure it inside the plugin