### PR TITLE
feat(gtm): add customDataLayer config

### DIFF
--- a/gitbook/API.md
+++ b/gitbook/API.md
@@ -17,7 +17,7 @@ autoData.init({
         tms: {
           name: 'gtm',
           parser: function(type, data) {}, // Optional
-          enhancer: function (parsedTag) {}, // Optional
+          enhancer: function(parsedTag) {}, // Optional
           sender: function(enhancedTag) {}, // Optional
         },
         plugins: {
@@ -45,7 +45,7 @@ This function allows you to add custom data on the already parsed tag. This coul
 ### tms.sender
 This function allows you to change how parsed and enhanced data is sent to TMS or any tag collector system. For example, when using GTM as TMS, it pushes values in Google's dataLayer object.
 
-## autoData.sendPageView
+### autoData.sendPageView
 
 This method needs to be used in an SPA or in a tunnel, where there is no page reload. In this contexte, the goal is to track each views/steps as pageviews (generally called virtual pageviews).
 
@@ -70,7 +70,7 @@ Result
 }
 ```
 
-## autoData.sendVirtualPageView (deprecated)
+### autoData.sendVirtualPageView (deprecated)
 
 Usage
 
@@ -91,7 +91,7 @@ Result
 }
 ```
 
-## autoData.sendEvent
+### autoData.sendEvent
 
 This method needs to be used for "functionals tags", when data attributes is not enough and/or if the tag is computed dynamically when user interacts with the website. Also, interacted elements handled in Javascript with a preventDefault needs to be tagged with this method.
 
@@ -137,6 +137,23 @@ Result
     "foo":    true,
     "bar":    false,
     "baz":    true
+}
+```
+
+## GTM specific settings
+
+### Provide a custom `dataLayer`
+You can specify your own `dataLayer` name be setting `dataLayerName` in `tms` config :
+
+```
+{
+    common: {
+        tms: {
+          name: 'gtm',
+          dataLayerName: "myDataLayer"
+        },
+        /* ... */
+    }
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autodata",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "main": "dist/autodata.js",
   "license": "MIT",
   "scripts": {

--- a/src/drivers/gtm.js
+++ b/src/drivers/gtm.js
@@ -36,12 +36,14 @@ export const parser = (type, data = {}) => {
 };
 
 /**
- * Send the parsed tag to dataLayer
- * @param {object} tag - parsed tag to be sent
+ * Create a sender
+ * @param {string} dataLayerName - name of the dataLayer to push events
+ * @returns {Function} - a sender
  */
-export const sender = tag => {
-  if (!window.dataLayer) {
-    window.dataLayer = [];
+export const sender = (dataLayerName = "dataLayer") => tag => {
+  if (!window[dataLayerName]) {
+    window[dataLayerName] = [];
   }
-  window.dataLayer.push(tag);
+
+  window[dataLayerName].push(tag);
 };

--- a/src/drivers/gtm.spec.js
+++ b/src/drivers/gtm.spec.js
@@ -2,88 +2,121 @@ import { expect } from "chai";
 import * as tagTypes from "../constants/tagTypes";
 import { config, parser, sender } from "./gtm";
 
-// Return last pushed layer
-const lastLayer = () => window.dataLayer.pop();
-// Tiny driver for test
-const gtm = (type, data) => sender(parser(type, data), type);
-
 describe("(Driver) gtm", () => {
-  it("should respect the correct default config", () => {
-    expect(config).deep.equals({
-      eventTracker: {
-        trigger: "obj",
-        attributes: ["act", "desc", "val"]
-      }
+  describe("sender initialization", () => {
+    after(() => {
+      delete window.dataLayer;
+    });
+
+    it('should use "dataLayer" as default data layer name', () => {
+      // WHEN
+      sender()("tag");
+
+      // THEN
+      expect(window.dataLayer)
+        .to.be.an("array")
+        .that.includes("tag");
+    });
+
+    it("should use a custom datalayer name", () => {
+      // WHEN
+      sender("customDataLayer")("tag");
+
+      // THEN
+      expect(window["customDataLayer"])
+        .to.an("array")
+        .that.includes("tag");
     });
   });
 
-  it(`should send ${tagTypes.EVENT} in correct format`, () => {
-    const data = { obj: "foo", desc: "bar" };
-    gtm(tagTypes.EVENT, data);
+  describe("sender calls", () => {
+    // Return last pushed layer
+    const lastLayer = () => window.dataLayer.pop();
 
-    expect(lastLayer()).deep.equals({
-      event: "click",
-      ...data
+    let gtm;
+    beforeEach(() => {
+      window.dataLayer = [];
+
+      gtm = (type, data) => sender()(parser(type, data), type);
     });
-  });
 
-  it(`should send ${tagTypes.VIRTUAL_PAGEVIEW} in correct format`, () => {
-    const data = { page: "/home", title: "home" };
-    gtm(tagTypes.VIRTUAL_PAGEVIEW, data);
-
-    expect(lastLayer()).deep.equals({
-      event: "virtualpageview",
-      ...data
+    it("should respect the correct default config", () => {
+      expect(config).deep.equals({
+        eventTracker: {
+          trigger: "obj",
+          attributes: ["act", "desc", "val"]
+        }
+      });
     });
-  });
 
-  it(`should send ${tagTypes.PAGEVIEW} in correct format`, () => {
-    const data = { page: "/home", title: "home" };
-    gtm(tagTypes.PAGEVIEW, data);
+    it(`should send ${tagTypes.EVENT} in correct format`, () => {
+      const data = { obj: "foo", desc: "bar" };
+      gtm(tagTypes.EVENT, data);
 
-    expect(lastLayer()).deep.equals({
-      event: "pageview",
-      ...data
+      expect(lastLayer()).deep.equals({
+        event: "click",
+        ...data
+      });
     });
-  });
 
-  it(`should send ${tagTypes.MEDIA_QUERY} in correct format`, () => {
-    const data = { name: "breakpoint", value: "foo" };
-    gtm(tagTypes.MEDIA_QUERY, data);
+    it(`should send ${tagTypes.VIRTUAL_PAGEVIEW} in correct format`, () => {
+      const data = { page: "/home", title: "home" };
+      gtm(tagTypes.VIRTUAL_PAGEVIEW, data);
 
-    expect(lastLayer()).deep.equals({
-      event: "media-query",
-      ...data
+      expect(lastLayer()).deep.equals({
+        event: "virtualpageview",
+        ...data
+      });
     });
-  });
 
-  it(`should send ${tagTypes.OUTBOUND_FORM} in correct format`, () => {
-    const data = { action: "http://foo.bar" };
-    gtm(tagTypes.OUTBOUND_FORM, data);
+    it(`should send ${tagTypes.PAGEVIEW} in correct format`, () => {
+      const data = { page: "/home", title: "home" };
+      gtm(tagTypes.PAGEVIEW, data);
 
-    expect(lastLayer()).deep.equals({
-      event: "outbound-form",
-      ...data
+      expect(lastLayer()).deep.equals({
+        event: "pageview",
+        ...data
+      });
     });
-  });
 
-  it(`should send ${tagTypes.OUTBOUND_LINK} in correct format`, () => {
-    const data = { href: "http://foo.bar" };
-    gtm(tagTypes.OUTBOUND_LINK, data);
+    it(`should send ${tagTypes.MEDIA_QUERY} in correct format`, () => {
+      const data = { name: "breakpoint", value: "foo" };
+      gtm(tagTypes.MEDIA_QUERY, data);
 
-    expect(lastLayer()).deep.equals({
-      event: "outbound-link",
-      ...data
+      expect(lastLayer()).deep.equals({
+        event: "media-query",
+        ...data
+      });
     });
-  });
 
-  it(`should send ${tagTypes.SOCIAL} in correct format`, () => {
-    const data = { name: "foo", action: "bar" };
-    gtm(tagTypes.SOCIAL, data);
+    it(`should send ${tagTypes.OUTBOUND_FORM} in correct format`, () => {
+      const data = { action: "http://foo.bar" };
+      gtm(tagTypes.OUTBOUND_FORM, data);
 
-    expect(lastLayer()).deep.equals({
-      event: "social",
-      ...data
+      expect(lastLayer()).deep.equals({
+        event: "outbound-form",
+        ...data
+      });
+    });
+
+    it(`should send ${tagTypes.OUTBOUND_LINK} in correct format`, () => {
+      const data = { href: "http://foo.bar" };
+      gtm(tagTypes.OUTBOUND_LINK, data);
+
+      expect(lastLayer()).deep.equals({
+        event: "outbound-link",
+        ...data
+      });
+    });
+
+    it(`should send ${tagTypes.SOCIAL} in correct format`, () => {
+      const data = { name: "foo", action: "bar" };
+      gtm(tagTypes.SOCIAL, data);
+
+      expect(lastLayer()).deep.equals({
+        event: "social",
+        ...data
+      });
     });
   });
 });

--- a/src/drivers/index.js
+++ b/src/drivers/index.js
@@ -26,7 +26,7 @@ export default function getInstance(config) {
   switch (tms.name) {
     case "gtm":
       parsers.push(gtm.parser);
-      senders.push(gtm.sender);
+      senders.push(gtm.sender(config.tms.dataLayerName));
       break;
     case "tealium":
       parsers.push(tealium.parser);


### PR DESCRIPTION
A new config property `(string) dataLayerName` is available in GTM (only) `tms` config.