### PR TITLE
Fix UMD build

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,19 +1,19 @@
-import {resolve} from 'path';
-import webpack from 'webpack';
-import HTMLWebpackPlugin from 'html-webpack-plugin';
-import {BundleAnalyzerPlugin} from 'webpack-bundle-analyzer';
-import rules from './webpack.loaders';
-import ENV from './ENV.json';
+import { resolve } from "path";
+import webpack from "webpack";
+import HTMLWebpackPlugin from "html-webpack-plugin";
+import { BundleAnalyzerPlugin } from "webpack-bundle-analyzer";
+import rules from "./webpack.loaders";
+import ENV from "./ENV.json";
 
-const [isProd, isDev, isLocal] = [
-  'production', 'development', 'local',
-].map(env => process.env.NODE_ENV === env);
+const [isProd, isDev, isLocal] = ["production", "development", "local"].map(
+  env => process.env.NODE_ENV === env
+);
 
 // Format vars for webpack ENV process
-const formatVars = (VARS) => {
+const formatVars = VARS => {
   const obj = {};
   Object.entries(VARS).forEach(([name, value]) => {
-    obj[name] = typeof value === 'string' ? JSON.stringify(value) : value;
+    obj[name] = typeof value === "string" ? JSON.stringify(value) : value;
   });
   return obj;
 };
@@ -21,55 +21,57 @@ const formatVars = (VARS) => {
 let plugins = [
   new webpack.DefinePlugin({
     __DEV__: isDev || isLocal,
-    __ENV__: isLocal ? {
-      ...formatVars(ENV),
-    } : false,
-  }),
+    __ENV__: isLocal
+      ? {
+          ...formatVars(ENV)
+        }
+      : false
+  })
 ];
 let entry = {
-  autodata: './src/autodata.js',
+  autodata: "./src/autodata.js"
 };
 
 if (isLocal) {
   entry = {
-    demo: './src/demo/demo.jsx',
+    demo: "./src/demo/demo.jsx"
   };
   plugins = plugins.concat([
     new HTMLWebpackPlugin({
-      title: 'Autodata',
-      template: './src/demo/index.html',
-      inject: 'body',
-      chunksSortMode: 'none',
-    }),
+      title: "Autodata",
+      template: "./src/demo/index.html",
+      inject: "body",
+      chunksSortMode: "none"
+    })
   ]);
 }
 
 if (isProd) {
   plugins = plugins.concat([
     new BundleAnalyzerPlugin({
-      analyzerMode: 'static',
+      analyzerMode: "static",
       openAnalyzer: true,
-      reportFilename: resolve(__dirname, 'report/bundle-analyzer.html'),
-    }),
+      reportFilename: resolve(__dirname, "report/bundle-analyzer.html")
+    })
   ]);
 }
 
 export default {
-  mode: isProd ? 'production' : 'development',
+  mode: isProd ? "production" : "development",
   entry,
   output: {
     path: resolve(`${__dirname}/dist`),
-    filename: isProd ? '[name].min.js' : '[name].js',
-    library: 'autoData',
-    libraryTarget: 'umd',
-    libraryExport: 'default',
-    globalObject: 'this'
+    filename: isProd ? "[name].min.js" : "[name].js",
+    library: "autoData",
+    libraryTarget: "umd",
+    libraryExport: "default",
+    globalObject: "this"
   },
   resolve: {
-    extensions: ['.js', '.jsx', '.json'],
+    extensions: [".js", ".jsx", ".json"]
   },
   module: {
-    rules,
+    rules
   },
-  plugins,
+  plugins
 };

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -62,6 +62,8 @@ export default {
     filename: isProd ? '[name].min.js' : '[name].js',
     library: 'autoData',
     libraryTarget: 'umd',
+    libraryExport: 'default',
+    globalObject: 'this'
   },
   resolve: {
     extensions: ['.js', '.jsx', '.json'],


### PR DESCRIPTION
### Bug description

Current UMD build exposes the ES6 module object wrapper instead of the default exported object.

<img width="601" alt="Capture d’écran 2019-08-12 à 20 13 59" src="https://user-images.githubusercontent.com/6979207/62887857-67e20b00-bd3e-11e9-8d24-e913731410fe.png">

### Cause

Newly installed Webpack version is missing the `libraryExport` configuration.

### Fix

Add `libraryExport: "default"` to Webpack production configuration.

---

I'll contact NPM support to unpublish the 0.16.0 version.